### PR TITLE
published docker hub image rhqproject/rhq-nodb does not work

### DIFF
--- a/rhq-nodb-deploy.sh
+++ b/rhq-nodb-deploy.sh
@@ -14,7 +14,10 @@ then
 fi
 sed -i 's;^jboss\.bind\.address.*$;jboss.bind.address=0.0.0.0;g' ${RHQ_HOME}/bin/rhq-server.properties
 
-${RHQ_HOME}/bin/rhqctl install 
+# provide autoinstall default password for user rhqadmin as rhqadmin:
+sed -i 's;^rhq\.autoinstall\.server\.admin\.password.*$;rhq.autoinstall.server.admin.password=x1XwrxKuPvYUILiOnOZTLg==;g' ${RHQ_HOME}/bin/rhq-server.properties
+
+${RHQ_HOME}/bin/rhqctl install
 ${RHQ_HOME}/bin/rhqctl start
 
 tail -F ${RHQ_HOME}/logs/server.log


### PR DESCRIPTION
As described in #5 

The published docker image rhqproject/rhq-nodb on the docker hub does not work and hangs forever once started.

I believe this is because the run script file invoke the installer `rhqctl install`, the installer does not find in the server properties a default admin password, hence prompts the user with:

```
The [rhq.autoinstall.server.admin.password] property is required but not set in [rhq-server.properties].
Do you want to set [rhq.autoinstall.server.admin.password] value now?
```

(I've checked by running this manually myself); but the installer is running as a java process inside the container itself, hence there is no way this is going to ever move on or start the application itself.

I've solved by proving a default `rhq.autoinstall.server.admin.password` property for the user `rhqadmin` as `rhqadmin`:

```
$ ./rhq-encode-value.sh 
Property rhq.autoinstall.server.admin.password [y/n]: y
Password: rhqadmin

Encoded password for rhq-server.properties:
     rhq.autoinstall.server.admin.password=x1XwrxKuPvYUILiOnOZTLg==
```

I believe that would be the solution, as additionally it would also follow similar style of already defined default passwords for other admins users (e.g.: `rhq.server.database.password`) in the server properties file. If there is a better solution kindly let me know.

Meanwhile, I will raise a PR accordingly to make explicit my proposed solution.
